### PR TITLE
replaceCommonSourcePath, parseSourceDirectory, getCommonSourcePath expec...

### DIFF
--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -257,7 +257,7 @@ class CbErrorHandler
     public function getFilesWithErrors ($cbXMLFileName)
     {
         $element = $this->cbXMLHandler->loadXML($cbXMLFileName);
-        $files   = null;
+        $files   = array();
         $path    = '';
         
         foreach ($element->children() as $file) {


### PR DESCRIPTION
When running phpcb and no errors are found following errors / warnings happen

PHP Warning:  Invalid argument supplied for foreach() in /Users/michiel/Documents/workspace/PHP_CodeBrowser/src/ErrorHandler.php on line 103

Similar errors also happen but are not listed here, the problem is that the $files variable in getFilesWithErrors is initialised with null and should be array() instead. 

...t an array and not null (happens when there are no errors)
